### PR TITLE
fix added constructors for /voter/nether/ender/overworld

### DIFF
--- a/src/main/java/net/novelmc/Converse.java
+++ b/src/main/java/net/novelmc/Converse.java
@@ -132,6 +132,10 @@ public class Converse extends JavaPlugin {
         getCommand("staffworld").setExecutor(new StaffworldCommand());
         getCommand("unban").setExecutor(new UnbanCommand());
         getCommand("unloadchunks").setExecutor(new UnloadChunksCommand());
+        getCommand("voterworld").setExecutor(new VoterworldCommand());
+        getCommand("overworld").setExecutor(new OverworldCommand());
+        getCommand("netherworld").setExecutor(new NetherworldCommand());
+        getCommand("enderworld").setExecutor(new EnderworldCommand());
 
     }
 

--- a/src/main/java/net/novelmc/bridge/LuckPermsBridge.java
+++ b/src/main/java/net/novelmc/bridge/LuckPermsBridge.java
@@ -193,4 +193,34 @@ public class LuckPermsBridge {
             userManager.saveUser(user);
         });
     }
+    
+    public void allowVoterWorld(UUID uuid) {
+        assert api != null;
+        UserManager userManager = api.getUserManager();
+        CompletableFuture<User> userFuture = userManager.loadUser(uuid);
+
+        userFuture.thenAcceptAsync(user ->
+        {
+            Node permission = api.buildNode("multiverse.access.voterworld").build();
+            Node command = api.buildNode("converse.voterworld").build();
+            user.setPermission(permission);
+            user.setPermission(command);
+            userManager.saveUser(user);
+        });
+    }
+    
+    public void disallowVoterWorld(UUID uuid) {
+        assert api != null;
+        UserManager userManager = api.getUserManager();
+        CompletableFuture<User> userFuture = userManager.loadUser(uuid);
+
+        userFuture.thenAcceptAsync(user ->
+        {
+            Node permission = api.buildNode("multiverse.access.voterworld").build();
+            Node command = api.buildNode("converse.voterworld").build();
+            user.unsetPermission(permission);
+            user.unsetPermission(command);
+            userManager.saveUser(user);
+        });
+    }
 }

--- a/src/main/java/net/novelmc/commands/EnderworldCommand.java
+++ b/src/main/java/net/novelmc/commands/EnderworldCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class FlatworldCommand implements CommandExecutor {
+public class EnderworldCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
         World world_the_end = Bukkit.getWorld("world_the_end");

--- a/src/main/java/net/novelmc/commands/NetherworldCommand.java
+++ b/src/main/java/net/novelmc/commands/NetherworldCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class FlatworldCommand implements CommandExecutor {
+public class NetherworldCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
         World world_nether = Bukkit.getWorld("world_nether");

--- a/src/main/java/net/novelmc/commands/OverworldCommand.java
+++ b/src/main/java/net/novelmc/commands/OverworldCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class FlatworldCommand implements CommandExecutor {
+public class OverworldCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
         World world = Bukkit.getWorld("world");

--- a/src/main/java/net/novelmc/commands/VoterworldCommand.java
+++ b/src/main/java/net/novelmc/commands/VoterworldCommand.java
@@ -11,6 +11,11 @@ import org.bukkit.entity.Player;
 public class VoterworldCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
+        if (!sender.hasPermission("converse.voterworld")) {
+            sender.sendMessage(Messages.NO_PERMISSION);
+            return true;
+        }
+        
         World voterworld = Bukkit.getWorld("voterworld");
         if (voterworld == null) {
             sender.sendMessage(ChatColor.RED +

--- a/src/main/java/net/novelmc/commands/VoterworldCommand.java
+++ b/src/main/java/net/novelmc/commands/VoterworldCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class FlatworldCommand implements CommandExecutor {
+public class VoterworldCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] args) {
         World voterworld = Bukkit.getWorld("voterworld");

--- a/src/main/java/net/novelmc/listeners/WorldListener.java
+++ b/src/main/java/net/novelmc/listeners/WorldListener.java
@@ -40,6 +40,15 @@ public class WorldListener implements Listener {
             plugin.lp.disallowStaffWorld(event.getPlayer().getUniqueId());
         }
     }
+    
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        if (event.getPlayer().hasPermission("multiverse.access.voterworld") &&
+                !plugin.lp.isStaff(event.getPlayer().getUniqueId()) ||
+                !plugin.lp.isArchitect(event.getPlayer().getUniqueId())) {
+            plugin.lp.disallowVoterWorld(event.getPlayer().getUniqueId());
+        }
+    }
 
     private boolean bool = Converse.plugin.config.getBoolean("item_drops");
 


### PR DESCRIPTION
1. class names of each constructor were overlooked in relation to the command
2. voterworld command constructor did not look for the right permission node
3. disallowvoterworld event-handler (expansion on previous)