### PR TITLE
Cage & Playtime Functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/net/novelmc/Converse.java
+++ b/src/main/java/net/novelmc/Converse.java
@@ -25,6 +25,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.UUID;
 
 public class Converse extends JavaPlugin {
     public static Converse plugin;
@@ -57,6 +58,7 @@ public class Converse extends JavaPlugin {
     public PlayerDataListener pdl;
     public TabListener sl;
     public WorldListener wl;
+    public CageListener cgl;
 
 
     @Override
@@ -99,6 +101,9 @@ public class Converse extends JavaPlugin {
     public void onDisable() {
         // Unregister configs
         unregisterConfigs();
+
+        // Undo cages
+        for(UUID u : cgl.cages.keySet()) { CageCommand.Cage cage = cgl.cages.get(u); cage.undo(); } cgl.cages.clear();
     }
 
     private void loadShops() {
@@ -141,6 +146,7 @@ public class Converse extends JavaPlugin {
         getCommand("unloadchunks").setExecutor(new UnloadChunksCommand());
         getCommand("orbit").setExecutor(new OrbitCommand());
         getCommand("say").setExecutor(new SayCommand());
+        getCommand("cage").setExecutor(new CageCommand());
 
     }
 
@@ -153,7 +159,7 @@ public class Converse extends JavaPlugin {
         sl = new TabListener(this);
         wl = new WorldListener(this);
         shl = new ShopListener(this);
-
+        cgl = new CageListener(this);
     }
 
     public void registerConfigs() {

--- a/src/main/java/net/novelmc/Converse.java
+++ b/src/main/java/net/novelmc/Converse.java
@@ -59,6 +59,7 @@ public class Converse extends JavaPlugin {
     public TabListener sl;
     public WorldListener wl;
     public CageListener cgl;
+    public PlaytimeListener ptl;
 
 
     @Override
@@ -104,6 +105,10 @@ public class Converse extends JavaPlugin {
 
         // Undo cages
         for(UUID u : cgl.cages.keySet()) { CageCommand.Cage cage = cgl.cages.get(u); cage.undo(); } cgl.cages.clear();
+
+        // Playtime Handler
+        ptl.schedular.cancel();
+        ptl.saveData();
     }
 
     private void loadShops() {
@@ -147,6 +152,8 @@ public class Converse extends JavaPlugin {
         getCommand("orbit").setExecutor(new OrbitCommand());
         getCommand("say").setExecutor(new SayCommand());
         getCommand("cage").setExecutor(new CageCommand());
+        getCommand("playtime").setExecutor(new PlaytimeCommand());
+
 
     }
 
@@ -160,6 +167,7 @@ public class Converse extends JavaPlugin {
         wl = new WorldListener(this);
         shl = new ShopListener(this);
         cgl = new CageListener(this);
+        ptl = new PlaytimeListener(this);
     }
 
     public void registerConfigs() {

--- a/src/main/java/net/novelmc/commands/CageCommand.java
+++ b/src/main/java/net/novelmc/commands/CageCommand.java
@@ -1,0 +1,99 @@
+package net.novelmc.commands;
+
+import net.novelmc.util.ConverseBase;
+import net.novelmc.util.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public class CageCommand extends ConverseBase implements CommandExecutor {
+    public class Cage {
+        private UUID uuid;
+        private Material cageMaterial;
+        private Map<Location, Material> previousBlocks = new HashMap<>();
+
+        public Cage(Player player, Material cageMaterial) {
+            this.uuid = player.getUniqueId();
+            this.cageMaterial = cageMaterial;
+        }
+
+        public void createCage() {
+            final Block center = Objects.requireNonNull(Bukkit.getPlayer(uuid)).getLocation().getBlock();
+            for (int xOffset = -2; xOffset <= 2; xOffset++) {
+                for (int yOffset = -2; yOffset <= 2; yOffset++) {
+                    for (int zOffset = -2; zOffset <= 2; zOffset++) {
+                        if (Math.abs(xOffset) != 2 && Math.abs(yOffset) != 2 && Math.abs(zOffset) != 2) continue;
+                        final Block block = center.getRelative(xOffset, yOffset, zOffset);
+                        previousBlocks.put(block.getLocation(), block.getType());
+                        block.setType(cageMaterial);
+                    }
+                }
+            }
+        }
+
+        public void undo() {
+            for(Location loc : previousBlocks.keySet()) {
+                loc.getBlock().setType(previousBlocks.get(loc));
+            }
+        }
+    }
+
+    // Usage: /cage <player> [block]
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if(sender.hasPermission("converse.cage")) {
+            if (args.length == 0) return false;
+            else {
+                if(!args[0].equalsIgnoreCase("purge")) {
+                    Player target = Bukkit.getPlayer(args[0]);
+                    if (target != null) {
+                        if (!plugin.cgl.cages.containsKey(target.getUniqueId())) {
+                            if (!target.hasPermission("converse.cage")) {
+                                Material cageMaterial = Material.GLASS;
+                                if (args.length > 1) {
+                                    Material matchedMaterial = Material.matchMaterial(args[1]);
+                                    ;
+                                    if (matchedMaterial != null) cageMaterial = matchedMaterial;
+                                }
+
+                                Cage cage = new Cage(target, cageMaterial);
+                                cage.createCage();
+
+                                plugin.cgl.cages.put(target.getUniqueId(), cage);
+                                Util.action(sender, "Caged " + target.getName());
+                            } else {
+                                sender.sendMessage(ChatColor.RED + "You can't cage this person!");
+                            }
+                        } else {
+                            plugin.cgl.cages.get(target.getUniqueId()).undo();
+                            plugin.cgl.cages.remove(target.getUniqueId());
+                            Util.action(sender, "Uncaged " + target.getName());
+                        }
+                    } else {
+                        sender.sendMessage(Messages.PLAYER_NOT_FOUND);
+                    }
+                } else {
+                    Util.action(sender, "Removing all cages");
+                    for(UUID u : plugin.cgl.cages.keySet()) {
+                        Cage cage = plugin.cgl.cages.get(u);
+                        cage.undo();
+                    }
+                    plugin.cgl.cages.clear();
+                }
+            }
+        } else {
+            sender.sendMessage(Messages.NO_PERMISSION);
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/novelmc/commands/Messages.java
+++ b/src/main/java/net/novelmc/commands/Messages.java
@@ -3,6 +3,6 @@ package net.novelmc.commands;
 import org.bukkit.ChatColor;
 
 public class Messages {
-    static final String NO_PERMISSION = ChatColor.RED + "You do not have permission to execute this commmand!";
+    static final String NO_PERMISSION = ChatColor.RED + "You do not have permission to execute this command!";
     static final String PLAYER_NOT_FOUND = ChatColor.RED + "Player not found!";
 }

--- a/src/main/java/net/novelmc/commands/PlaytimeCommand.java
+++ b/src/main/java/net/novelmc/commands/PlaytimeCommand.java
@@ -1,0 +1,52 @@
+package net.novelmc.commands;
+
+import net.novelmc.util.ConverseBase;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.concurrent.TimeUnit;
+
+public class PlaytimeCommand extends ConverseBase implements CommandExecutor {
+    @SuppressWarnings("deprecated")
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if(args.length == 0) {
+            if(sender instanceof Player) {
+                plugin.ptl.cachePlayerPlaytime((Player) sender);
+                sender.sendMessage(ChatColor.AQUA + "Your playtime: " + ChatColor.WHITE +
+                        formattedTime(plugin.ptl.playtime.get(((Player) sender).getUniqueId())));
+            } else {
+                sender.sendMessage(ChatColor.RED + "This command is only executable by a player!");
+            }
+        } else {
+            Player target = Bukkit.getPlayer(args[0]);
+            OfflinePlayer offlineTarget = Bukkit.getOfflinePlayer(args[0]);
+            if(target != null) {
+                plugin.ptl.cachePlayerPlaytime(target);
+                sender.sendMessage(ChatColor.AQUA + target.getName()+ "'s playtime: " + ChatColor.WHITE +
+                        formattedTime(plugin.ptl.playtime.get(target.getUniqueId())));
+            } else {
+                if(plugin.ptl.playtime.containsKey(offlineTarget.getUniqueId())) {
+                    sender.sendMessage(ChatColor.AQUA + offlineTarget.getName()+ "'s playtime: " + ChatColor.WHITE +
+                            formattedTime(plugin.ptl.playtime.get(offlineTarget.getUniqueId())));
+                } else {
+                    sender.sendMessage(Messages.PLAYER_NOT_FOUND);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public String formattedTime(Long timeMillis) {
+        long seconds = timeMillis / 1000;
+        long days = (int)TimeUnit.SECONDS.toDays(seconds);
+        long hours = TimeUnit.SECONDS.toHours(seconds) - (days *24);
+        long minutes = TimeUnit.SECONDS.toMinutes(seconds) - (TimeUnit.SECONDS.toHours(seconds)* 60);
+        return String.format("%d day(s), %d hour(s), %d minute(s)", days, hours, minutes);
+    }
+}

--- a/src/main/java/net/novelmc/listeners/CageListener.java
+++ b/src/main/java/net/novelmc/listeners/CageListener.java
@@ -1,0 +1,56 @@
+package net.novelmc.listeners;
+
+import net.novelmc.Converse;
+import net.novelmc.commands.CageCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CageListener implements Listener {
+    private final Converse plugin;
+    public final Map<UUID, CageCommand.Cage> cages = new HashMap<>();
+
+    public CageListener(Converse plugin) {
+        this.plugin = plugin;
+        Bukkit.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent e) {
+        if(cages.containsKey(e.getPlayer().getUniqueId())) {
+            CageCommand.Cage cage = cages.get(e.getPlayer().getUniqueId());
+            cage.undo();
+        }
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent e) {
+        if(cages.containsKey(e.getPlayer().getUniqueId())) {
+            CageCommand.Cage cage = cages.get(e.getPlayer().getUniqueId());
+            cage.createCage();
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onBreak(BlockBreakEvent e) {
+        if(cages.containsKey(e.getPlayer().getUniqueId())) e.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onProcessCommand(PlayerCommandPreprocessEvent e) {
+        if(cages.containsKey(e.getPlayer().getUniqueId())) {
+            e.getPlayer().sendMessage(ChatColor.RED + "While caged, you can not use any commands!");
+            e.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/net/novelmc/listeners/PlaytimeListener.java
+++ b/src/main/java/net/novelmc/listeners/PlaytimeListener.java
@@ -1,0 +1,96 @@
+package net.novelmc.listeners;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.novelmc.Converse;
+import net.novelmc.commands.CageCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+
+public class PlaytimeListener implements Listener {
+    public BukkitTask schedular;
+    public Map<UUID, Long> playtime = new HashMap<>();
+    public Map<UUID, Long> timeLoggedIn = new HashMap<>();
+    public Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private final Converse plugin;
+    public final Map<UUID, CageCommand.Cage> cages = new HashMap<>();
+
+    public PlaytimeListener(Converse plugin) {
+        this.plugin = plugin;
+        Bukkit.getServer().getPluginManager().registerEvents(this, plugin);
+
+        if(new File(plugin.getDataFolder(), "playtime.json").exists()) loadData();
+        beginScheduler();
+    }
+
+    private void beginScheduler() {
+        schedular = new BukkitRunnable() {
+            public void run() {
+                for(Player player : Bukkit.getOnlinePlayers()) {
+                    cachePlayerPlaytime(player);
+                }
+
+                saveData();
+            }
+        }.runTaskTimerAsynchronously(plugin, 0L, 6000L);
+    }
+
+    public void saveData() {
+        try {
+            FileWriter fw = new FileWriter(new File(plugin.getDataFolder(), "playtime.json"));
+            gson.toJson(playtime, fw);
+            fw.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void loadData() {
+        try {
+            FileReader fr = new FileReader(new File(plugin.getDataFolder(), "playtime.json"));
+            Type type = new TypeToken<Map<UUID, Long>>() { }.getType();
+            playtime = gson.fromJson(fr, type);
+            fr.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void cachePlayerPlaytime(Player player) {
+        Long loggedInAt = timeLoggedIn.get(player.getUniqueId());
+        Long currentTimeMillis = System.currentTimeMillis();
+        Long diffTime = currentTimeMillis - loggedInAt;
+        timeLoggedIn.put(player.getUniqueId(), currentTimeMillis);
+        playtime.put(player.getUniqueId(), playtime.get(player.getUniqueId()) + diffTime);
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent e) {
+        timeLoggedIn.put(e.getPlayer().getUniqueId(), System.currentTimeMillis());
+        if(!playtime.containsKey(e.getPlayer().getUniqueId())) {
+            playtime.put(e.getPlayer().getUniqueId(), 0L);
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent e) {
+        cachePlayerPlaytime(e.getPlayer());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -98,3 +98,6 @@ commands:
   cage:
     usage: /<command> <<player> [block] | purge>
     description: Create a cage around a player
+  playtime:
+    usage: /<command> [player]
+    description: View player playtime

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -95,3 +95,6 @@ commands:
     usage: /<command>
     description: Teleport to the voterworld
     aliases: [vw]
+  cage:
+    usage: /<command> <<player> [block] | purge>
+    description: Create a cage around a player


### PR DESCRIPTION
The first implementation for this pull request is cages. These cages will prevent you from doing commands and breaking blocks. To create a cage you would use **/cage <player> [block]**, to uncage a player you would do **/cage <player>**. Finally, in order to purge all cages you would do **/cage purge**.

The second implementation for this pull request is playtime. This is viewable by doing /playtime [player]. Every five minutes, it will automatically cache and save playtime to the file. (It will also save when you leave, but the automatic saving is to prevent huge loss of data with crashes)